### PR TITLE
do not show config file missing warning if application start with -m …

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,5 @@
 #include "config.h"
 #include <errno.h>
-#include <unistd.h>
 #include <fstream>
 #include <string.h>
 #include <spdlog/spdlog.h>
@@ -35,8 +34,8 @@ bool Config::parse(const char *file, bool silence)
             if (!silence)
             {
                 char cwd[PATH_MAX];
-                spdlog::error("[Config::parse] cwd[{}]. config file[{}] open fail. {}",
-                              getcwd(cwd, PATH_MAX), file, errno, strerror(errno));
+                spdlog::warn("[Config::parse] can not open config file[{}]. {} - {}",
+                              file, errno, strerror(errno));
             }
             return false;
         }
@@ -51,21 +50,17 @@ bool Config::parse(const char *file, bool silence)
     return true;
 }
 
-bool Config::parse(const char *file, vector<string> &argMapData)
+void Config::parse(const char *file, vector<string> &argMapData)
 {
     // parse config file
-    if (!parse(file))
-    {
-        return false;
-    }
+    bool silence = !argMapData.empty();
+    parse(file, silence);
 
     // parse map data from args
     for (auto mapData : argMapData)
     {
         parseLine(mapData);
     }
-
-    return true;
 }
 
 string Config::get(string key, string section, string defaultValue)

--- a/src/config.h
+++ b/src/config.h
@@ -42,7 +42,7 @@ public:
     Config();
 
     bool parse(const char *file, bool silence = false);
-    bool parse(const char *file, std::vector<std::string> &argMapData);
+    void parse(const char *file, std::vector<std::string> &argMapData);
     std::string get(std::string key, std::string section = "", std::string defaultValue = "");
     std::vector<MapData_t> &getMapData();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,11 +80,7 @@ void init(int argc, char *argv[])
         const char *cfgFile = getArg(argv, argv + argc, "-c");
         std::vector<std::string> argMapData;
         getArgMapData(argc, argv, "-m", argMapData);
-        if (!gConf.parse(cfgFile ? cfgFile : CONFIG_FILE, argMapData))
-        {
-            perror("[init] load config file fail");
-            std::exit(EXIT_FAILURE);
-        }
+        gConf.parse(cfgFile ? cfgFile : CONFIG_FILE, argMapData);
 
         // get max sessions
         {


### PR DESCRIPTION
do not show config file missing warning if application start with -m args.